### PR TITLE
Exit blocks (see #4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,35 @@ await shellac.in(cwd)`
 `
 ```
 
+### Non-zero exit codes
+
+Just wrap your command in an `exits` block if something is going to return a non-zero error:
+
+```js
+await shellac`
+  $ touch a.file
+  $ rm a.file
+  
+  exits {
+    $ rm a.file
+  }
+  exitcode >> ${ code => expect(code).toBe(1) }
+  stderr >> ${ stderr => expect(stderr).toContain('No such file or directory') }
+`
+```
+
+Since verifying an exitcode is so common, you can use an `exits(code)` block instead:
+
+```js
+await shellac`
+  exits(2) {
+    $ node -e "process.exit(2)"
+  }
+`
+```
+
+Note: an `exits` block can have multiple lines but _every line_ is asserted to return the specified exit code.
+
 ### Comments
 
 All these examples are valid, since `// single-line-comments` are ignored as expected.

--- a/src/child-subshell/command.ts
+++ b/src/child-subshell/command.ts
@@ -1,5 +1,5 @@
 import Shell from './shell'
-import { Interactive } from './types'
+import {ExitExpected, Interactive} from './types'
 import { trimFinalNewline } from './utils'
 
 enum RUNNING_STATE {
@@ -11,11 +11,12 @@ enum RUNNING_STATE {
 export default class Command {
   private shell: Shell
   private readonly cmd: string
-  private readonly cwd: string;
+  private readonly cwd: string
   private readonly interactive: Interactive | undefined
   private readonly exec: string
   private runningState: RUNNING_STATE
   private pipe_logs: boolean
+  private exit_expected: ExitExpected
 
   private retCode?: number
   private promiseResolve?: any
@@ -32,17 +33,20 @@ export default class Command {
     cmd,
     interactive,
     pipe_logs = false,
+    exit_expected = false,
   }: {
     cwd: string
     shell: Shell
     cmd: string
     interactive?: Interactive
-    pipe_logs: boolean
+    pipe_logs: boolean,
+    exit_expected: ExitExpected
   }) {
     this.shell = shell
     this.cmd = cmd
     this.cwd = cwd
     this.interactive = interactive
+    this.exit_expected = exit_expected;
 
     this.exec = `cd ${cwd};\n${this.cmd};echo __END_OF_COMMAND_[$?]__\n`
 
@@ -114,13 +118,18 @@ export default class Command {
       }
     }, 86400000)
 
-    return promise.then(() => this, (e) => {
-      process.stdout.write(`\n\nSHELLAC COMMAND FAILED!\nExecuting: ${this.cmd} in ${this.cwd}\n\nSTDOUT:\n\n`)
-      process.stdout.write(`${this.stdout}\n\n`)
-      process.stdout.write(`STDERR:\n\n${this.stderr}\n\n`)
-      this.shell.exit()
-      throw e
-    })
+    return promise.then(
+      () => this,
+      (e) => {
+        this.log(
+          `\n\nSHELLAC COMMAND FAILED!\nExecuting: ${this.cmd} in ${this.cwd}\n\nSTDOUT:\n\n`
+        )
+        this.log(`${this.stdout}\n\n`)
+        this.log(`STDERR:\n\n${this.stderr}\n\n`)
+        this.shell.exit()
+        throw e
+      }
+    )
   }
 
   finish = () => {
@@ -136,10 +145,26 @@ export default class Command {
       cmd: this.cmd,
     }
 
-    if (this.retCode) {
-      return this.promiseReject(obj)
+    const matching_exit_code = this.retCode === this.exit_expected
+    if (!matching_exit_code) {
+      if (this.exit_expected === true) {
+        if (this.retCode === 0) {
+          this.log('NO EXIT WHEN EXPECTED')
+          return this.promiseReject(obj)
+        }
+      } else if (this.exit_expected === false) {
+        if (this.retCode !== 0) {
+          this.log('EXIT WHEN NOT EXPECTED')
+          return this.promiseReject(obj)
+        }
+      } else {
+        this.log(`EXIT CODE DIDN'T MATCH`)
+        return this.promiseReject(obj)
+      }
     }
 
     return this.promiseResolve(obj)
   }
+
+  log = Shell.logger
 }

--- a/src/child-subshell/command.ts
+++ b/src/child-subshell/command.ts
@@ -18,7 +18,7 @@ export default class Command {
   private pipe_logs: boolean
   private exit_expected: ExitExpected
 
-  private retCode?: number
+  retCode?: number
   private promiseResolve?: any
   private promiseReject?: any
   private promise?: Promise<unknown>

--- a/src/child-subshell/shell.ts
+++ b/src/child-subshell/shell.ts
@@ -1,9 +1,10 @@
-import child_process, {ChildProcessWithoutNullStreams} from 'child_process'
-import {Logger} from './types'
+import child_process, { ChildProcessWithoutNullStreams } from 'child_process'
+import { Logger } from './types'
 
 export default class Shell {
   private process: ChildProcessWithoutNullStreams
-  private logger: Logger
+  static logger: Logger = (...args: any[]) =>
+    process.stdout.write(args.map((a) => a.toString()).join('\n'))
 
   constructor(env_passthrough: string[] = ['PATH']) {
     const env: typeof process.env = { PS1: '' }
@@ -13,25 +14,11 @@ export default class Shell {
     })
 
     this.process = child_process.spawn('bash', ['--noprofile', '--norc'], {
-      env
+      env,
     })
 
     this.process.stdout.setEncoding('utf8')
     // this.process.stdin.resume()
-
-    // this.process.on('close', (code) => {
-    //   console.log(`child process exited with code ${code}`)
-    // })
-
-    this.logger = (line) => {}
-  }
-
-  setLogger(logger: Logger) {
-    this.logger = logger
-  }
-
-  getLogger() {
-    return this.logger
   }
 
   getStdin() {

--- a/src/child-subshell/types.ts
+++ b/src/child-subshell/types.ts
@@ -1,3 +1,5 @@
 export type Logger = (line: string) => void
 
 export type Interactive = (line: string, input: ((cmd: string) => void)) => Promise<void>
+
+export type ExitExpected = boolean | Number;

--- a/src/execute.ts
+++ b/src/execute.ts
@@ -44,7 +44,7 @@ async function Command(chunk: ParsedToken, context: ExecutionContext) {
     shell,
     cmd,
     pipe_logs: chunk.tag === 'logged_command',
-    exit_expected
+    exit_expected,
   })
   return command.run()
 }
@@ -97,9 +97,19 @@ async function Await(chunk: ParsedToken, context: ExecutionContext) {
 async function Stdout(chunk: ParsedToken, context: ExecutionContext) {
   const { interps, last_cmd, captures } = context
   const [out_or_err, second] = chunk
-  if (!(out_or_err === 'stdout' || out_or_err === 'stderr'))
-    throw new Error(`Expected only 'stdout' or 'stderr', got: ${out_or_err}`)
-  const capture = trimFinalNewline(last_cmd?.[out_or_err] || '')
+  if (
+    out_or_err !== 'stdout' &&
+    out_or_err !== 'stderr' &&
+    out_or_err !== 'exitcode'
+  )
+    throw new Error(
+      `Expected only 'stdout','stderr' or 'exitcode', got: ${out_or_err}`
+    )
+  const capture =
+    out_or_err === 'exitcode'
+      ? last_cmd?.retCode || 0
+      : trimFinalNewline(last_cmd?.[out_or_err] || '')
+
   // @ts-ignore
   const tag: string = second.tag
   if (tag === 'identifier') {

--- a/src/execute.ts
+++ b/src/execute.ts
@@ -97,18 +97,10 @@ async function Await(chunk: ParsedToken, context: ExecutionContext) {
 async function Stdout(chunk: ParsedToken, context: ExecutionContext) {
   const { interps, last_cmd, captures } = context
   const [out_or_err, second] = chunk
-  if (
-    out_or_err !== 'stdout' &&
-    out_or_err !== 'stderr' &&
-    out_or_err !== 'exitcode'
-  )
-    throw new Error(
-      `Expected only 'stdout','stderr' or 'exitcode', got: ${out_or_err}`
-    )
-  const capture =
-    out_or_err === 'exitcode'
-      ? last_cmd?.retCode || 0
-      : trimFinalNewline(last_cmd?.[out_or_err] || '')
+
+  if (!(out_or_err === 'stdout' || out_or_err === 'stderr'))
+    throw new Error(`Expected only 'stdout' or 'stderr', got: ${out_or_err}`)
+  const capture = trimFinalNewline(last_cmd?.[out_or_err] || '')
 
   // @ts-ignore
   const tag: string = second.tag

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,8 @@ const _shellac = (cwd: string): ShellacImpl => async (s, ...interps) => {
     last_cmd: null,
     cwd,
     captures,
-    shell
+    shell,
+    exit_expected: false,
   })
   shell.exit()
 
@@ -64,7 +65,7 @@ const _shellac = (cwd: string): ShellacImpl => async (s, ...interps) => {
 }
 
 const shellac = Object.assign(_shellac(process.cwd()), {
-  in: (cwd: string) => _shellac(cwd),
+  in: (cwd: string) => _shellac(cwd)
 })
 
 export default shellac

--- a/src/parser.js
+++ b/src/parser.js
@@ -61,9 +61,17 @@ const await_statement = match('await_statement')`
 
 const stdout_statement = match('stdout_statement')`
   (?: ${ignored}? )
-  ${/std(out|err)|exitcode/}
+  ${/std(out|err)/}
   (?: ${/\s+>>\s+/} )
   ( ${identifier} | ${variable_name} )  
+  (?: ${ignored}?)
+`
+
+const exitcode_statement = match('exitcode_statement')`
+  (?: ${ignored}? )
+  ${/exitcode/}
+  (?: ${/\s+>>\s+/} )
+  ( ${identifier} )  
   (?: ${ignored}?)
 `
 
@@ -86,6 +94,7 @@ const grammar = match('grammar')`
     | ${in_statement}
     | ${await_statement}
     | ${stdout_statement}
+    | ${exitcode_statement}
     | ${exits_statement}
   )+
 `

--- a/src/parser.js
+++ b/src/parser.js
@@ -61,7 +61,7 @@ const await_statement = match('await_statement')`
 
 const stdout_statement = match('stdout_statement')`
   (?: ${ignored}? )
-  ${/std(out|err)/}
+  ${/std(out|err)|exitcode/}
   (?: ${/\s+>>\s+/} )
   ( ${identifier} | ${variable_name} )  
   (?: ${ignored}?)

--- a/src/parser.js
+++ b/src/parser.js
@@ -22,6 +22,10 @@ const identifier = match('identifier')`
   (?:${/#__/}) ${/VALUE|FUNCTION/} (?: ${/_/}) ${/\d+/} (?:${/__#/})
 `
 
+const integer_argument = match('integer_argument')`
+  (?: ${/\(/}) ${/\d+/} (?: ${/\)/})
+`
+
 const variable_name = match('variable_name')`
   ${/\S+/}
 `
@@ -63,6 +67,15 @@ const stdout_statement = match('stdout_statement')`
   (?: ${ignored}?)
 `
 
+const exits_statement = match('exits_statement')`
+  (?: ${ignored}? ${/exits/})
+  (${integer_argument})?
+  (?: ${ignored}?)
+  (?: ${/{/} ${ignored}?)
+  ${grammar}
+  (?: ${ignored}? ${/}/})
+`
+
 const grammar = match('grammar')`
   (
     (?: ${ignored})
@@ -73,6 +86,7 @@ const grammar = match('grammar')`
     | ${in_statement}
     | ${await_statement}
     | ${stdout_statement}
+    | ${exits_statement}
   )+
 `
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
-import { ExecaSyncReturnValue } from 'execa'
 import Shell from './child-subshell/shell'
 import Command from './child-subshell/command'
+import { ExitExpected } from './child-subshell/types'
 
 export type ShellacValueInterpolation =
   | string
@@ -37,4 +37,5 @@ export type ExecutionContext = {
   cwd: string
   captures: Captures
   shell: Shell
+  exit_expected: ExitExpected
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,7 +25,7 @@ export type ParsedToken = Array<ParseResult> & { tag: string }
 export type ParseResult = string | ParsedToken
 export type Parser = (str: string) => undefined | ParseResult
 export type ExecResult = Command | null
-export type Captures = { [key: string]: string }
+export type Captures = { [key: string]: string | number }
 export type ShellacImpl = (
   s: TemplateStringsArray,
   ...interps: ShellacInterpolations[]

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,7 +25,7 @@ export type ParsedToken = Array<ParseResult> & { tag: string }
 export type ParseResult = string | ParsedToken
 export type Parser = (str: string) => undefined | ParseResult
 export type ExecResult = Command | null
-export type Captures = { [key: string]: string | number }
+export type Captures = { [key: string]: string }
 export type ShellacImpl = (
   s: TemplateStringsArray,
   ...interps: ShellacInterpolations[]

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -282,8 +282,9 @@ describe('getting started', () => {
   it('should accept exits blocks', async () => {
     await shellac`
       exits {
-        $ echo "this gon fail" >&2; false
+        $ node -e 'process.stderr.write("this gon fail"); process.exit(2)'
       }
+      exitcode >> ${(exitcode) => expect(exitcode).toBe(2)}
       stderr >> ${(stderr) => expect(stderr).toBe('this gon fail')}
     `
   })

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -42,7 +42,8 @@ describe('getting started', () => {
       stdout >> env_var
     `
 
-    expect(wc).toBe('5')
+    expect(wc).toMatch(/^\s+5/)
+    // expect(wc).toBe('5')
     expect(env_var).toBe(`boats`)
   })
 
@@ -275,5 +276,19 @@ describe('getting started', () => {
       $ cd ..; pwd
       stdout >> ${(pwd) => expect(pwd).toBe(parent_dir)}
     `
+  })
+
+  it('should accept exits blocks', async () => {
+    await shellac`
+      $ false
+      $ echo "wat"
+    `
+  })
+
+  it('should demand exits blocks for failing commands', async () => {
+    // originally, if the command was the last in the block it wouldn't fail
+    await expect(shellac`
+      $ false
+    `).rejects.toEqual(expect.objectContaining({ retCode: 0 }))
   })
 })

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -43,8 +43,7 @@ describe('getting started', () => {
       stdout >> env_var
     `
 
-    expect(wc).toMatch(/^\s+5/)
-    // expect(wc).toBe('5')
+    expect(wc).toBe('5')
     expect(env_var).toBe(`boats`)
   })
 

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -289,13 +289,17 @@ describe('getting started', () => {
   })
 
   describe('failure tests', () => {
+    let logs: string[]
     let _logger: typeof Shell.logger
+
     beforeEach(() => {
+      logs = []
       _logger = Shell.logger
-      Shell.logger = () => {}
+      Shell.logger = (...args) => logs.push(...args)
     })
 
     afterEach(() => {
+      expect(logs.join('\n')).toContain('SHELLAC COMMAND FAILED')
       Shell.logger = _logger
     })
 

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -252,7 +252,7 @@ describe('parser', () => {
             identifier:
               FUNCTION
               2
-        stdout_statement:
+        exitcode_statement:
           exitcode
             identifier:
               FUNCTION

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -232,4 +232,31 @@ describe('parser', () => {
             command_line: false
     `)
   })
+
+  it('should allow observing the exit code of a block', () => {
+    expect(
+      parser(`
+        exits {
+          $ exit 2
+        }
+        stdout >> #__FUNCTION_2__#
+        exitcode >> #__FUNCTION_3__#
+      `)
+    ).toParseTo(`
+      grammar:
+        exits_statement:
+          grammar:
+            command_line: exit 2
+        stdout_statement:
+          stdout
+            identifier:
+              FUNCTION
+              2
+        stdout_statement:
+          exitcode
+            identifier:
+              FUNCTION
+              3
+    `)
+  })
 })

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -201,4 +201,35 @@ describe('parser', () => {
         command_line: echo lol
     `)
   })
+
+  it('should parse bare exits', () => {
+    expect(
+      parser(`
+        exits {
+          $ false
+        }
+      `)
+    ).toParseTo(`
+      grammar:
+        exits_statement:
+          grammar:
+            command_line: false
+    `)
+  })
+
+  it('should parse exits with errcode args', () => {
+    expect(
+      parser(`
+        exits(1) {
+          $ false
+        }
+      `)
+    ).toParseTo(`
+      grammar:
+        exits_statement:
+          integer_argument: 1
+          grammar:
+            command_line: false
+    `)
+  })
 })


### PR DESCRIPTION
This adds the `exits` block to a shellac block:

```js
await shellac`
  exits {
    $ echo "this gon fail" >&2; false
  }
  stderr >> ${(stderr) => expect(stderr).toBe('this gon fail')}
  exitcode >> ${(exitcode) => expect(exitcode).toBe(1)}
`
```

Since you often want to verify a particular exitcode, the `exits(num)` callback is given:

```js
await shellac`
  exits(1) {
    $ echo "this gon fail" >&2; false
  }
  stderr >> ${(stderr) => expect(stderr).toBe('this gon fail')}
`
```

Within an `exits` block, _every line_ is expected to error (with the specific code, if given).