### PR TITLE
Fix and test for directories with spaces, and for whitespace test issue

### DIFF
--- a/src/child-subshell/command.ts
+++ b/src/child-subshell/command.ts
@@ -48,7 +48,7 @@ export default class Command {
     this.interactive = interactive
     this.exit_expected = exit_expected;
 
-    this.exec = `cd ${cwd};\n${this.cmd};echo __END_OF_COMMAND_[$?]__\n`
+    this.exec = `cd "${cwd}";\n${this.cmd};echo __END_OF_COMMAND_[$?]__\n`
 
     this.shell.getStdout().on('data', this.handleStdoutData)
     this.shell.getStderr().on('data', this.handleStderrData)

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -43,7 +43,7 @@ describe('getting started', () => {
       stdout >> env_var
     `
 
-    expect(wc).toBe('5')
+    expect(wc.trim()).toBe('5')
     expect(env_var).toBe(`boats`)
   })
 
@@ -216,6 +216,19 @@ describe('getting started', () => {
             '└── some.file',
           ].join('\n')
         )}
+    `
+  })
+
+  it('should handle directories with spaces', async () => {
+    const dir = await tmp.dir({ unsafeCleanup: true })
+    await shellac`
+      $ mkdir "${dir.path}/lol boats"
+      in ${path.join(dir.path, 'lol boats')} {
+        $$ pwd
+      }     
+      stdout >> ${async (output) =>
+        expect(output).toContain('lol boats')
+      }
     `
   })
 


### PR DESCRIPTION
Adds a test and a fix for the bug where directories with spaces would hang when using shellac (was occuring when using Shellac in a directory with a space in releasecast):
https://github.com/superhighfives/releasecast/blob/2fa6f6c881e66730d3fb08ae718323f12a3a5a75/src/index.ts#L48)

Also trims whitespace for the `should handle bash-y things` test, which was failing on macOS.