### PR TITLE
Fix support for Scoop-installed Bash on Windows

### DIFF
--- a/src/child-subshell/shell.ts
+++ b/src/child-subshell/shell.ts
@@ -1,4 +1,5 @@
 import child_process, { ChildProcessWithoutNullStreams } from 'child_process'
+import os from 'os'
 import { Logger } from './types'
 
 export default class Shell {
@@ -14,7 +15,8 @@ export default class Shell {
 
     this.process = child_process.spawn('bash', ['--noprofile', '--norc'], {
       env,
-      detached: true,
+      // use detached mode except on Windows where it's not compatible with all builds of bash
+      detached: os.platform() !== "win32",
     })
 
     this.process.stdout.setEncoding('utf8')


### PR DESCRIPTION
Suggested fix from https://github.com/geelen/shellac/issues/14

(I'm not sure if `detached: true` is important for some case on non-Windows systems; if it's not important then a simpler fix would be to leave it unset so it's always false.)