### PR TITLE
Fix spawn error due to security vulnerability in later versions of node 18.x 20.x 21.x

### DIFF
--- a/src/child-subshell/shell.ts
+++ b/src/child-subshell/shell.ts
@@ -15,6 +15,7 @@ export default class Shell {
     this.process = child_process.spawn('bash', ['--noprofile', '--norc'], {
       env,
       detached: true,
+      shell: true
     })
 
     this.process.stdout.setEncoding('utf8')


### PR DESCRIPTION
Nodejs.org

https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2#command-injection-via-args-parameter-of-child_processspawn-without-shell-option-enabled-on-windows-cve-2024-27980---high